### PR TITLE
[codex] Remove retired upload-artifact fallback

### DIFF
--- a/.github/actions/prepare-zip-from-dir/action.yml
+++ b/.github/actions/prepare-zip-from-dir/action.yml
@@ -105,30 +105,9 @@ runs:
           echo "location=$FINAL_ZIP" >> "$GITHUB_OUTPUT"
         fi
 
-    - name: Detect GitHub Server Type
+    - name: Upload ZIP artifact
       if: ${{ inputs.attach-zip == 'true' }}
-      shell: bash
-      run: |
-        echo "🔍 Detecting GitHub server type..."
-        echo "   Server URL: ${{ github.server_url }}"
-        if [[ "${{ github.server_url }}" == *"github.com"* ]] || [[ "${{ github.server_url }}" == *"ghe.com"* ]]; then
-          echo "✅ Detected: GitHub Cloud (github.com or ghe.com)"
-          echo "   → Using upload-artifact@v4"
-        else
-          echo "✅ Detected: GitHub Enterprise Server"
-          echo "   → Using upload-artifact@v3"
-        fi
-
-    - name: Upload ZIP artifact (v4 - GitHub Cloud)
-      if: ${{ inputs.attach-zip == 'true' && (contains(github.server_url, 'github.com') || contains(github.server_url, 'ghe.com')) }}
       uses: actions/upload-artifact@v4
-      with:
-        name: ${{ steps.prepare-zip.outputs.package_dir_name }}
-        path: ${{ steps.prepare-zip.outputs.location }}
-
-    - name: Upload ZIP artifact (v3 - GitHub Enterprise Server)
-      if: ${{ inputs.attach-zip == 'true' && !contains(github.server_url, 'github.com') && !contains(github.server_url, 'ghe.com') }}
-      uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.prepare-zip.outputs.package_dir_name }}
         path: ${{ steps.prepare-zip.outputs.location }}

--- a/.github/workflows/analyze-changes.yml
+++ b/.github/workflows/analyze-changes.yml
@@ -212,38 +212,8 @@ jobs:
           cat "${{ steps.create-pid-csvs.outputs.delete-csv }}" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Detect GitHub Server Type
-        run: |
-          echo "🔍 Detecting GitHub server type..."
-          echo "   Server URL: ${{ github.server_url }}"
-          if [[ "${{ github.server_url }}" == *"github.com"* ]] || [[ "${{ github.server_url }}" == *"ghe.com"* ]]; then
-            echo "✅ Detected: GitHub Cloud (github.com or ghe.com)"
-            echo "   → Using upload-artifact@v4"
-          else
-            echo "✅ Detected: GitHub Enterprise Server"
-            echo "   → Using upload-artifact@v3"
-          fi
-
-      - name: Upload built artifacts (v4 - GitHub Cloud)
-        if: ${{ contains(github.server_url, 'github.com') || contains(github.server_url, 'ghe.com') }}
+      - name: Upload built artifacts
         uses: actions/upload-artifact@v4
-        with:
-          name: git-diff-result.zip
-          path: |
-            ${{ steps.get-compare-packages.outputs.files_changed }}
-            ${{ steps.get-compare-packages.outputs.base_dir_file }}
-            ${{ steps.get-compare-packages.outputs.target_dir_file }}
-            ${{ steps.get-compare-partnerdir.outputs.files_changed }}
-            ${{ steps.get-compare-partnerdir.outputs.base_dir_file }}
-            ${{ steps.get-compare-partnerdir.outputs.target_dir_file }}
-            ${{ steps.create-package-csvs.outputs.upload-csv }}
-            ${{ steps.create-package-csvs.outputs.delete-csv }}
-            ${{ steps.create-pid-csvs.outputs.upload-csv }}
-            ${{ steps.create-pid-csvs.outputs.delete-csv }}
-
-      - name: Upload built artifacts (v3 - GitHub Enterprise Server)
-        if: ${{ !contains(github.server_url, 'github.com') && !contains(github.server_url, 'ghe.com') }}
-        uses: actions/upload-artifact@v3
         with:
           name: git-diff-result.zip
           path: |


### PR DESCRIPTION
## Summary

- Remove the conditional `actions/upload-artifact@v3` fallback branches from `prepare-zip-from-dir` and `analyze-changes`.
- Keep artifact uploads on `actions/upload-artifact@v4`, so GitHub Cloud no longer pre-validates a retired v3 action reference before `if:` conditions run.

Fixes #14.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest`
- `python3` YAML parse for `.github/actions/prepare-zip-from-dir/action.yml` and `.github/workflows/analyze-changes.yml`
- `rg -n "uses:\s+actions/upload-artifact@v3" .github/actions/prepare-zip-from-dir/action.yml .github/workflows/analyze-changes.yml || true`
- `git diff --check`

No package-level test command is present in this repository.